### PR TITLE
fix bug that prevents images from being deleted

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -177,6 +177,8 @@ docker-registry:
       fields:
         service: registry
     storage:
+      delete:
+        enabled: true
       cache:
         blobdescriptor: inmemory
     http:


### PR DESCRIPTION
# Description

Calls to remove images from shipa registry failed, causing problems in the calling code, and the images themselves were never removed from the registry.  The problem was caused by incorrect configuration and has been fixed. 

Fixes #[SHIPA-848](https://shipaio.atlassian.net/browse/SHIPA-848?atlOrigin=eyJpIjoiYjE5M2M4OGQ2NGMwNDgwYWJmNzc5NzYwZTNhYjlkZDIiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
